### PR TITLE
fix: 修复串口名称显示错误

### DIFF
--- a/SuperCom/Core/Entity/SerialPortEx.cs
+++ b/SuperCom/Core/Entity/SerialPortEx.cs
@@ -177,7 +177,7 @@ namespace SuperCom.Entity
                 portNames = GetPortNames();
                 using (var searcher = new ManagementObjectSearcher(PORT_INFO_SELECT_SQL)) {
                     var ports = searcher.Get().Cast<ManagementBaseObject>().ToList().Select(p => p["Caption"].ToString());
-                    var portList = portNames.Select(n => n + " - " + ports.FirstOrDefault(s => s.Contains(n))).ToList();
+                    var portList = portNames.Select(n => n + " - " + ports.FirstOrDefault(s => s.EndsWith(n+")"))).ToList();
                     foreach (string detail in portList) {
                         Logger.Info(detail);
                         if (Regex.Match(detail, COM_PATTERN) is Match match && match.Success && match.Groups != null &&


### PR DESCRIPTION
错误原因:如COM16 包含 COM1 会导致COM1使用COM16的名称