### PR TITLE
修复 README 中失效的 star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SuperCom 是**超级串口调试工具**，用于 Window 串口日志的采集�
 
 [![p9reenx.png](https://s1.ax1x.com/2023/05/10/p9reenx.png)](https://imgse.com/i/p9reenx)
 
-![star-history](https://api.star-history.com/svg?repos=SuperStudio/SuperCom&type=Date)
+![star-history](https://star-history.dera.page/svg?repos=SuperStudio/SuperCom&type=Date)
 
 
 # 关于


### PR DESCRIPTION
README 中的 star 历史图表目前无法正常显示，原因是原图表接口受到 GitHub 限制。已将其切换到一个新的可用数据源，修复后图表可正常展示。